### PR TITLE
Add Komet Test to Detect Overflow in Vesting Calculation

### DIFF
--- a/contracts/test_manager/Cargo.toml
+++ b/contracts/test_manager/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test_manager"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/test_manager/kasmer.json
+++ b/contracts/test_manager/kasmer.json
@@ -1,0 +1,5 @@
+{
+    "contracts": [
+        "../token_vesting_manager"
+    ]
+  }

--- a/contracts/test_manager/src/komet.rs
+++ b/contracts/test_manager/src/komet.rs
@@ -1,0 +1,13 @@
+use soroban_sdk::{Address, Bytes, Env, FromVal, Val};
+
+extern "C" {
+    fn kasmer_create_contract(addr_val: u64, hash_val: u64) -> u64;
+}
+
+#[allow(dead_code)]
+pub fn create_contract(env: &Env, addr: &Bytes, hash: &Bytes) -> Address {
+    unsafe {
+        let res = kasmer_create_contract(addr.as_val().get_payload(), hash.as_val().get_payload());
+        Address::from_val(env, &Val::from_payload(res))
+    }
+}

--- a/contracts/test_manager/src/lib.rs
+++ b/contracts/test_manager/src/lib.rs
@@ -1,0 +1,84 @@
+#![no_std]
+use manager::{TokenVestingManagerClient, Vesting};
+use soroban_sdk::{contract, contractimpl, symbol_short, Bytes, Env, Symbol};
+
+mod komet;
+mod manager;
+
+pub const MANAGER_ADDR: &[u8; 32] = b"mngr_ctr________________________";
+pub const MANAGER_KEY: Symbol = symbol_short!("MNGR");
+
+
+#[contract]
+pub struct TestManagerContract;
+
+#[contractimpl]
+impl TestManagerContract {
+    pub fn init(env: Env, manager_hash: Bytes) {
+        let manager = komet::create_contract(&env, &Bytes::from_array(&env, &MANAGER_ADDR), &manager_hash);
+        env.storage().instance().set(&MANAGER_KEY, &manager);
+    }
+
+    /// Tests that all `linear_amt` tokens are fully vested at the end of the schedule.
+    /// 
+    /// # Parameters
+    /// - `start_t`: The start time of the vesting schedule.
+    /// - `end_t`: The end time of the vesting schedule.
+    /// - `linear_amt`: The total amount of tokens to be vested linearly over time.
+    /// - `interval`: The interval at which vesting progresses.
+    /// 
+    /// This test verifies that by `end_t`, the entire `linear_amt` has been vested.
+    pub fn test_all_vested_at_the_end(
+        env: Env,
+        start_t: u64,
+        end_t: u64,
+        linear_amt: i128,
+        interval: u64,
+    ) -> bool {
+
+        // Assume that the arguments satisfies the requirements made by the protocol
+
+        if end_t <= start_t // start_t should be less than end_t
+        || linear_amt <= 0  // linear amount should be positive
+        || interval == 0    // interval should be non-zero
+        {
+            return true;
+        }
+
+        let duration = end_t - start_t;
+        if duration % interval != 0 {   // duration should be a multiple of the interval
+            return true;
+        }
+
+        // // overflow check
+        // if linear_amt.checked_mul(duration as i128).is_none() {
+        //     return true;
+        // }
+
+        // Create a client for calling the vesting manager
+        let manager = env.storage().instance().get(&MANAGER_KEY).unwrap();
+        let manager_client = TokenVestingManagerClient::new(&env, &manager);
+
+        // Create a vesting with the given arguments
+        let vesting = Vesting {
+            recipient: env.current_contract_address(),
+            start_timestamp: start_t,
+            end_timestamp: end_t,
+            release_interval_secs: interval,
+            linear_vest_amount: linear_amt,
+            // default parameters. no cliff, no initial unlock, no timelock...
+            deactivation_timestamp: 0,
+            timelock: 0,
+            cliff_release_timestamp: 0,
+            initial_unlock: 0,
+            cliff_amount: 0,
+            claimed_amount: 0,
+        };
+
+        // Calculate the vested amount by the end of the schedule
+        let vested_amt = manager_client.calculate_vested_amount(&vesting, &end_t);
+
+        // Check that all the amount is vested
+        linear_amt == vested_amt
+    }
+}

--- a/contracts/test_manager/src/manager.rs
+++ b/contracts/test_manager/src/manager.rs
@@ -1,0 +1,27 @@
+use soroban_sdk::{contractclient, contracttype, Address, Env};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Vesting {
+    pub recipient: Address,
+    pub start_timestamp: u64,
+    pub end_timestamp: u64,
+    pub deactivation_timestamp: u64,
+    pub timelock: u64,
+    pub release_interval_secs: u64,
+    pub cliff_release_timestamp: u64,
+    pub initial_unlock: i128,
+    pub cliff_amount: i128,
+    pub linear_vest_amount: i128,
+    pub claimed_amount: i128,
+}
+
+#[allow(dead_code)]
+#[contractclient(name = "TokenVestingManagerClient")]
+pub trait TokenVestingManagerTrait {
+
+    fn init(env: Env, factory_caller: Address, token_address: Address);
+
+    fn calculate_vested_amount(_env: Env, vesting: Vesting, reference_timestamp: u64) -> i128;
+
+}


### PR DESCRIPTION
This PR adds a [Komet](https://komet.runtimeverification.com/) test to verify that all `vesting.linear_vest_amount` tokens are fully vested by the end of the schedule and to help detect potential overflow issues in the vesting calculation.  

## Installation & Running Instructions  

1. **Install Komet**  
   See the [Installation Docs](https://docs.runtimeverification.com/komet#id-1.3-installation).  

   First, install the `kup` package manager:  
   ```sh
   bash <(curl https://kframework.org/install)
   ```  
   Then, install **Komet**:  
   ```sh
   kup install komet
   ```  

2. **Run the Test**  
   ```sh
   komet test -C contracts/test_manager
   ```  
   By default, this runs the test 100 times. You can also specify a different number using the `--max-examples` argument:  
   ```sh
   komet test -C contracts/test_manager --max-examples <N>
   ```  

When you run the test, you’ll first see some compiler output—Komet compiles the contracts before execution. Then, a progress bar will appear as the test runs. If Komet finds an input that causes the test to fail, it will print the result.

![Screenshot_20250213_122957](https://github.com/user-attachments/assets/48db7400-c97e-42a0-89f1-a616ab9265a6)

   