### PR TITLE
FIX-B2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ target
 # Local settings
 .soroban
 .stellar
+
+# Tests
+**/test_snapshots

--- a/contracts/token_vesting_factory/src/lib.rs
+++ b/contracts/token_vesting_factory/src/lib.rs
@@ -17,9 +17,9 @@ const NEW_WASM_HASH: Symbol = symbol_short!("NEWHASH");
 const TOKEN_VESTING_MANAGER_CREATED: Symbol = symbol_short!("CREATED");
 
 // Minimum TTL before extending the instance lifetime: 20 days in 5 seconds ledger time
-const INSTANCE_LIFETIME_THRESHOLD: u32 = 345_600;
+const LIFETIME_THRESHOLD: u32 = 345_600;
 // Extension amount for the instance lifetime: 30 days in 5 seconds ledger time
-const INSTANCE_EXTENSION_AMOUNT: u32 = 518_400;
+const EXTENSION_AMOUNT: u32 = 518_400;
 
 #[contract]
 pub struct TokenVestingFactory;
@@ -30,7 +30,7 @@ impl TokenVestingFactory {
     pub fn extend_instance_ttl(e: &Env) {
         e.storage()
             .instance()
-            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_EXTENSION_AMOUNT);
+            .extend_ttl(LIFETIME_THRESHOLD, EXTENSION_AMOUNT);
     }
 
     /// Initialization function.

--- a/contracts/token_vesting_manager/src/lib.rs
+++ b/contracts/token_vesting_manager/src/lib.rs
@@ -105,8 +105,7 @@ impl TokenVestingManager {
             .set(&TOKEN_ADDRESS, &token_address);
 
         // Initialize tokens reserved for vesting with TTL extension
-        env.storage().persistent().set(&TOKENS_RESERVED_FOR_VESTING, &0_i128);
-        Self::extend_persistent_ttl(&env, TOKENS_RESERVED_FOR_VESTING);
+        env.storage().instance().set(&TOKENS_RESERVED_FOR_VESTING, &0_i128);
 
         // Set initial TTL
         Self::extend_instance_ttl(&env);
@@ -274,7 +273,6 @@ impl TokenVestingManager {
     pub fn claim(env: Env, caller: Address, vesting_id: u64) {
         Self::extend_instance_ttl(&env);
         Self::extend_persistent_ttl(&env, VESTING_BY_ID);
-        Self::extend_persistent_ttl(&env, TOKENS_RESERVED_FOR_VESTING);
 
         let mut vesting = Self::get_vesting_info(env.clone(), vesting_id.clone());
 
@@ -310,13 +308,13 @@ impl TokenVestingManager {
 
         let reserved_tokens: i128 = env
             .storage()
-            .persistent()
+            .instance()
             .get(&TOKENS_RESERVED_FOR_VESTING)
             .unwrap_or(0)
             - claimable;
 
         env.storage()
-            .persistent()
+            .instance()
             .set(&TOKENS_RESERVED_FOR_VESTING, &reserved_tokens);
 
         env.events().publish(
@@ -337,7 +335,6 @@ impl TokenVestingManager {
     pub fn revoke_vesting(env: Env, caller: Address, vesting_id: u64) {
         Self::extend_instance_ttl(&env);
         Self::extend_persistent_ttl(&env, VESTING_BY_ID);
-        Self::extend_persistent_ttl(&env, TOKENS_RESERVED_FOR_VESTING);
 
         let admins: Map<Address, bool> = env
             .storage()
@@ -377,13 +374,13 @@ impl TokenVestingManager {
 
         let reserved_tokens = env
             .storage()
-            .persistent()
+            .instance()
             .get(&TOKENS_RESERVED_FOR_VESTING)
             .unwrap_or(0)
             - amount_remaining;
 
         env.storage()
-            .persistent()
+            .instance()
             .set(&TOKENS_RESERVED_FOR_VESTING, &reserved_tokens);
 
         env.events().publish(
@@ -537,7 +534,7 @@ impl TokenVestingManager {
 
         let reserved_tokens: i128 = env
             .storage()
-            .persistent()
+            .instance()
             .get(&TOKENS_RESERVED_FOR_VESTING)
             .unwrap_or(0);
 
@@ -683,10 +680,9 @@ impl TokenVestingManager {
     /// Returns the amount of token reserved for vesting in the contract.
     pub fn get_tokens_reserved_for_vesting(env: Env) -> i128 {
         Self::extend_instance_ttl(&env);
-        Self::extend_persistent_ttl(&env, TOKENS_RESERVED_FOR_VESTING);
 
         env.storage()
-            .persistent()
+            .instance()
             .get(&TOKENS_RESERVED_FOR_VESTING)
             .unwrap_or(0)
     }
@@ -709,7 +705,6 @@ impl TokenVestingManager {
         linear_vest_amount: i128,
     ) -> u64 {
         Self::extend_instance_ttl(&env);
-        Self::extend_persistent_ttl(&env, TOKENS_RESERVED_FOR_VESTING);
         Self::extend_persistent_ttl(&env, RECIPIENTS);
         Self::extend_persistent_ttl(&env, RECIPIENT_VESTINGS);
         Self::extend_persistent_ttl(&env, VESTING_BY_ID);
@@ -751,13 +746,13 @@ impl TokenVestingManager {
 
         let reserved_tokens = env
             .storage()
-            .persistent()
+            .instance()
             .get(&TOKENS_RESERVED_FOR_VESTING)
             .unwrap_or(0_i128)
             + total_expected_amount;
 
         env.storage()
-            .persistent()
+            .instance()
             .set(&TOKENS_RESERVED_FOR_VESTING, &reserved_tokens);
 
         let vesting: Vesting = Vesting {

--- a/contracts/token_vesting_manager/src/lib.rs
+++ b/contracts/token_vesting_manager/src/lib.rs
@@ -101,6 +101,21 @@ impl TokenVestingManager {
         let admin_count: u32 = 1;
         env.storage().instance().set(&ADMIN_COUNT, &admin_count);
         env.storage().instance().set(&TOKEN_ADDRESS, &token_address);
+        env.storage()
+            .persistent()
+            .set(&RECIPIENTS, &Vec::<Address>::new(&env));
+        let empty_recipient_vestings: Map<Address, Vec<u64>> = Map::new(&env);
+        env.storage()
+            .persistent()
+            .set(&RECIPIENT_VESTINGS, &empty_recipient_vestings);
+        let empty_vesting_by_id: Map<u64, Vesting> = Map::new(&env);
+        env.storage()
+            .persistent()
+            .set(&VESTING_BY_ID, &empty_vesting_by_id);
+        env.storage().instance().set(&NONCE, &0_u64);
+        env.storage()
+            .instance()
+            .set(&TOKENS_RESERVED_FOR_VESTING, &0_i128);
 
         // Set initial TTL
         Self::extend_instance_ttl(&env);


### PR DESCRIPTION
- Uses the following instance TTL:
```
// Minimum TTL before extending the instance lifetime: 20 days in 5 seconds ledger time
const INSTANCE_LIFETIME_THRESHOLD: u32 = 345_600;
// Extension amount for the instance lifetime: 30 days in 5 seconds ledger time
const INSTANCE_EXTENSION_AMOUNT: u32 = 518_400;
```

- Assigns instance type to non-dynamic or less changed(admins) variables
- Added instance TTL manager on every method

